### PR TITLE
Debian DNS Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Images (mis)configured for blue team use.
 
 | Name | Operating System | Version | Description |
 | ---- | ---------------- | ------- | ----------- |
+| blue-debian-dnsmasq | Debian | 9 | Debian image configured with dnsmasq |
 | blue-redhat-lamp | Red Hat Linux | 7.0 | Red Hat image configured as a LAMP stack |
 | blue-ubuntu-lamp | Ubuntu Server | 18.04 | Ubuntu Server image configured as a LAMP stack |
 | blue-ubuntu-mongodb | Ubuntu Server | 18.04 | Ubuntu Server image configured with MongoDB |

--- a/images/blue-debian-dnsmasq.pkr.hcl
+++ b/images/blue-debian-dnsmasq.pkr.hcl
@@ -1,0 +1,44 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+source "amazon-ebs" "debian-stretch" {
+  ami_name = "blue-debian-dnsmasq"
+
+  instance_type = "t2.micro"
+  region        = "us-east-1"
+  source_ami    = "ami-0f643787e21058389"
+  ssh_username  = "admin"
+
+  force_deregister      = true
+  force_delete_snapshot = true
+
+  tag {
+    key   = "Name"
+    value = "Range Image"
+  }
+}
+
+build {
+  name = "dnsmasq"
+
+  sources = [
+    "source.amazon-ebs.debian-stretch"
+  ]
+
+  # Setup default blue team users
+  provisioner "shell" {
+    script = "./images/scripts/blue_default_users.sh"
+  }
+
+  # Setup default blue team users
+  provisioner "shell" {
+    script = "./images/scripts/blue_dnsmasq_install.sh"
+  }
+
+}

--- a/images/scripts/blue_dnsmasq_install.sh
+++ b/images/scripts/blue_dnsmasq_install.sh
@@ -1,0 +1,45 @@
+#! /bin/bash
+
+# Script to install dnsmasq
+
+echo "Installing dnsmasq..."
+
+sudo apt update
+
+sudo apt install dnsmasq -y
+
+# Dnsmasq configuration
+CONFIG="
+no-resolv
+server=1.1.1.1
+server=8.8.8.8
+"
+
+echo "Creating config file..."
+echo "$CONFIG" | sudo tee /etc/dnsmasq.conf > /dev/null
+
+# Range host configuration
+HOSTS="
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet
+ff00::0	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+
+10.0.10.5 dns.blue
+10.0.10.10 mongo.blue
+10.0.10.15 chat.blue
+10.0.10.20 work.blue
+
+10.0.10.50 ad.blue
+10.0.10.55 web.blue
+"
+
+echo "Creating hosts file..."
+echo "$HOSTS" | sudo tee /etc/hosts > /dev/null
+
+echo "Enabling service..."
+sudo systemctl enable dnsmasq
+
+echo "Done installing up dnsmasq."

--- a/images/scripts/blue_dnsmasq_install.sh
+++ b/images/scripts/blue_dnsmasq_install.sh
@@ -13,31 +13,20 @@ CONFIG="
 no-resolv
 server=1.1.1.1
 server=8.8.8.8
+listen-address=127.0.0.1,10.0.10.5
+
+# Range Hosts
+address=/dns.blue/10.0.10.5
+address=/mongo.blue/10.0.10.10
+address=/chat.blue/10.0.10.15
+address=/work.blue/10.0.10.20
+
+address=/ad.blue/10.0.10.50
+address=/web.blue/10.0.10.55
 "
 
 echo "Creating config file..."
 echo "$CONFIG" | sudo tee /etc/dnsmasq.conf > /dev/null
-
-# Range host configuration
-HOSTS="
-127.0.0.1	localhost
-::1	localhost ip6-localhost ip6-loopback
-fe00::0	ip6-localnet
-ff00::0	ip6-mcastprefix
-ff02::1	ip6-allnodes
-ff02::2	ip6-allrouters
-
-10.0.10.5 dns.blue
-10.0.10.10 mongo.blue
-10.0.10.15 chat.blue
-10.0.10.20 work.blue
-
-10.0.10.50 ad.blue
-10.0.10.55 web.blue
-"
-
-echo "Creating hosts file..."
-echo "$HOSTS" | sudo tee /etc/hosts > /dev/null
 
 echo "Enabling service..."
 sudo systemctl enable dnsmasq


### PR DESCRIPTION
Adds a Debian Stretch image configured with dnsmasq to act as a DNS server. 

Configured to resolve some .blue addresses to Range hosts. For instance dns.blue resolves to 10.0.10.5.
Other queries are forwarded to 1.1.1.1 or 8.8.8.8.

Resolves #1 